### PR TITLE
Install GitHub CLI in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,12 @@
 FROM ghcr.io/geocompx/pythonr
 
+# Install GitHub CLI
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+  && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+  && apt-get update \
+  && apt-get install gh -y
+
 RUN R -e "remotes::install_github('itsleeds/tds')"
 
 # Copy and install Python requirements first to leverage Docker layer cache


### PR DESCRIPTION
Fixes #152. Added installation steps for the GitHub CLI in the Dockerfile.