### PR TITLE
Add routing engine setup documentation link to session 5

### DIFF
--- a/s5/index.qmd
+++ b/s5/index.qmd
@@ -56,8 +56,8 @@ tmap_mode("plot")
 ## Using OpenTripPlanner to get routes
 
 We have set up the Multi-modal routing service OpenTripPlanner for West
-Yorkshire. Try typing this URL https://otp.robinlovelace.net/ 
-during the session into your browser. You should see something like
+Yorkshire. Try typing this URL during the session into your browser (provided by your instructor). 
+The service was set up using Docker with a reverse proxy for HTTPS, as documented at https://tdscience.github.io/dstp/routing-engine.html. You should see something like
 this:
 
 ![](images/otp_screenshot.png)


### PR DESCRIPTION
This PR makes a minor update to s5/index.qmd:

- Removes specific deployment URL (otp.robinlovelace.net)
- Adds a sentence explaining how the OTP service was set up
- Links to https://tdscience.github.io/dstp/routing-engine.html for documentation