### PR TITLE
fix: stats19 v4 column rename + dodgr R 4.6 build fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,7 +38,8 @@ Imports:
     dodgr,
     opentripplanner,
     osmextract,
-    tmap
+    tmap,
+    sfnetworks
 Remotes:
     Nowosad/spDataLarge
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,6 +30,7 @@ Imports:
     reticulate,
     stplanr,
     spData,
+    spDataLarge,
     zoo,
     pct,
     zonebuilder,
@@ -38,3 +39,6 @@ Imports:
     opentripplanner,
     osmextract,
     tmap
+Remotes:
+    Nowosad/spDataLarge
+

--- a/d2/example.qmd
+++ b/d2/example.qmd
@@ -83,7 +83,7 @@ collisions_west_yorkshire_sf = collisions_2023_sf |>
   filter(police_force == "West Yorkshire") |>
   # Arrange in descending order of accident severity
   # so most severe accidents are plotted last:
-  arrange(desc(accident_severity))
+  arrange(desc(collision_severity))
 sf::write_sf(collisions_west_yorkshire_sf, "wy.gpkg")
 ```
 
@@ -97,7 +97,7 @@ osm_transport_network_20mph |>
 ggplot() +
   geom_sf(
     data = collisions_west_yorkshire_sf,
-    aes(colour = accident_severity, alpha = accident_severity)
+    aes(colour = collision_severity, alpha = collision_severity)
   ) +
   scale_alpha_manual(values = c(0.8, 0.4, 0.2))
 ```

--- a/d2/template.qmd
+++ b/d2/template.qmd
@@ -138,7 +138,7 @@ The following code was used to aggregate the data by hour:
 ```{r}
 collisions_hourly = collisions_2023 |>
   mutate(time = lubridate::hour(datetime)) |>
-  count(time, accident_severity) 
+  count(time, collision_severity) 
 ```
 
 # Initial data exploration
@@ -150,7 +150,7 @@ A visualisation of the data is shown below:
 #| layout-ncol: 2
 #| echo: false
 collisions_hourly |>
-  ggplot(aes(x = time, y = n, fill = accident_severity)) +
+  ggplot(aes(x = time, y = n, fill = collision_severity)) +
   geom_col(position = "dodge") 
 head(collisions_2023$police_force)
 collisions_2023_sf |>

--- a/demos/practical2.qmd
+++ b/demos/practical2.qmd
@@ -1,0 +1,19 @@
+
+
+```{r}
+library(sf)
+library(dplyr)
+library(spDataLarge)
+library(stplanr)      # for processing geographic transport data
+library(tmap)         # map-making (see Chapter 9)
+library(ggplot2)      # data visualization package
+library(sfnetworks)   # spatial network classes and functions 
+```
+
+
+```{r}
+zones = spDataLarge::bristol_zones
+tmap_mode("view")
+qtm(zones) +
+  qtm(spDataLarge::bristol_stations)
+```

--- a/p1/slides.qmd
+++ b/p1/slides.qmd
@@ -315,10 +315,12 @@ piggyback::pb_upload("desire_lines.geojson")
 
 ```{r, message=FALSE, eval=TRUE}
 # Set-up, after installing R and checking out www.pct.bike:
-u = "https://github.com/ITSLeeds/TDS/releases/download/0.1/desire_lines.geojson"
+u = "https://github.com/itsleeds/tds/releases/download/0.1/desire_lines.geojson"
+f = basename(u)
+if (!file.exists(f)) download.file(u, f, mode = "wb")
 library(dplyr)
 library(sf)
-desire_lines = read_sf(u)
+desire_lines = read_sf(f)
 ```
 
 ## Visualising data

--- a/p2/index.qmd
+++ b/p2/index.qmd
@@ -131,7 +131,10 @@ system("gh release upload 2025 supermarkets_points_cleaned.geojson --clobber")
 Import and visualise a dataset with supermarket names and locations with the following code (see the [source code of the practical](https://github.com/itsleeds/tds/discussions/166) to see how the supermarket data was obtained with `osmextract`):
 
 ```{r}
-supermarkets = sf::read_sf("https://github.com/ITSLeeds/tds/releases/download/2025/supermarkets_points_cleaned.geojson")
+u = "https://github.com/itsleeds/tds/releases/download/2025/supermarkets_points_cleaned.geojson"
+f = basename(u)
+if (!file.exists(f)) download.file(u, f, mode = "wb")
+supermarkets = sf::read_sf(f)
 library(tmap)
 tmap_mode("view")
 tm_shape(supermarkets) +

--- a/p3/index.qmd
+++ b/p3/index.qmd
@@ -783,9 +783,14 @@ Let's begin by loading the following two datasets
 #| output: false
 
 # load the station location dataset
-bike_docking_stations = read_sf("https://github.com/itsleeds/tds/releases/download/2025/p3-london-bike_docking_stations.geojson")
+u_stations = "https://github.com/itsleeds/tds/releases/download/2025/p3-london-bike_docking_stations.geojson"
+if (!file.exists("p3-london-bike_docking_stations.geojson")) download.file(u_stations, "p3-london-bike_docking_stations.geojson")
+bike_docking_stations = read_sf("p3-london-bike_docking_stations.geojson")
+
 # load the bike trip origin and destination dataset
-bike_trips = read_csv("https://github.com/itsleeds/tds/releases/download/2025/p3-london-bike_trips.csv")
+u_trips = "https://github.com/itsleeds/tds/releases/download/2025/p3-london-bike_trips.csv"
+if (!file.exists("p3-london-bike_trips.csv")) download.file(u_trips, "p3-london-bike_trips.csv")
+bike_trips = read_csv("p3-london-bike_trips.csv")
 ```
 
 Explore these datasets using the functions you have learnt (e.g. head, nrow)
@@ -926,8 +931,13 @@ To enhance the map, adding some background context could be useful. Let’s try 
 Let’s check how the background looks. You can also customize the colors of the rivers and parks by modifying the values assigned to `fill` and `color`.
 ```{r}
 # load the river and parks
-rivers = st_read("https://github.com/itsleeds/tds/releases/download/2025/p3-london-rivers.geojson")
-parks = st_read("https://github.com/itsleeds/tds/releases/download/2025/p3-london-parks.geojson")
+u_rivers = "https://github.com/itsleeds/tds/releases/download/2025/p3-london-rivers.geojson"
+if (!file.exists("p3-london-rivers.geojson")) download.file(u_rivers, "p3-london-rivers.geojson")
+rivers = st_read("p3-london-rivers.geojson")
+
+u_parks = "https://github.com/itsleeds/tds/releases/download/2025/p3-london-parks.geojson"
+if (!file.exists("p3-london-parks.geojson")) download.file(u_parks, "p3-london-parks.geojson")
+parks = st_read("p3-london-parks.geojson")
 
 ggplot() +
   geom_sf(data = parks, fill = "#d9f5e0", color = "#d9f5e0") + # add parks in central London to the map
@@ -976,7 +986,9 @@ First, let create the buffer zones for tube stations in central london
 
 ```{r}
 # import the tube station data
-tube_stations = read_sf("https://github.com/itsleeds/tds/releases/download/2025/p3-london-tube_stations.geojson")
+u_tube = "https://github.com/itsleeds/tds/releases/download/2025/p3-london-tube_stations.geojson"
+if (!file.exists("p3-london-tube_stations.geojson")) download.file(u_tube, "p3-london-tube_stations.geojson")
+tube_stations = read_sf("p3-london-tube_stations.geojson")
 
 # use the bounding box of the bike docking stations to crop the tube stations
 # this can help us focus on central London - which is covered by the LCHS

--- a/p3/index.qmd
+++ b/p3/index.qmd
@@ -669,7 +669,7 @@ tm_shape(desire_lines) + # Define the data frame used to make the map
     lwd = "all"
   ) + # The line width (lwd) is based on the "all" column
   tm_layout(legend.outside = TRUE) + # Move the ledgend outside the map
-  tm_scale_bar() # Add a scale bar to the map
+  tm_scalebar() # Add a scale bar to the map
 ```
 
 ## R: ggplot2

--- a/p4/index.qmd
+++ b/p4/index.qmd
@@ -141,8 +141,10 @@ To get some more routes, we will start by importing some data. The `NTEM_flow.ge
 
 
 ```{r loaddesirelines, message=FALSE}
-u = "https://github.com/ITSLeeds/TDS/releases/download/22/NTEM_flow.geojson"
-desire_lines = read_sf(u)
+u = "https://github.com/itsleeds/tds/releases/download/22/NTEM_flow.geojson"
+f = basename(u)
+if (!file.exists(f)) download.file(u, f, mode = "wb")
+desire_lines = read_sf(f)
 head(desire_lines)
 ```
 
@@ -150,8 +152,10 @@ head(desire_lines)
 We will also download the points that represent the possible start and end point of trips in the model
 
 ```{r loadcentroids, message=FALSE}
-u = "https://github.com/ITSLeeds/TDS/releases/download/22/NTEM_cents.geojson"
-centroids = read_sf(u)
+u = "https://github.com/itsleeds/tds/releases/download/22/NTEM_cents.geojson"
+f = basename(u)
+if (!file.exists(f)) download.file(u, f, mode = "wb")
+centroids = read_sf(f)
 head(centroids)
 ```
 **Exercise** 
@@ -327,10 +331,14 @@ piggyback::pb_upload("routes_transit.geojson")
 ```
 
 ```{r, message=FALSE, echo=TRUE}
-u = "https://github.com/ITSLeeds/TDS/releases/download/22/routes_drive.geojson"
-routes_drive = read_sf(u)
-u = "https://github.com/ITSLeeds/TDS/releases/download/22/routes_transit.geojson"
-routes_transit = read_sf(u)
+u = "https://github.com/itsleeds/tds/releases/download/22/routes_drive.geojson"
+f = basename(u)
+if (!file.exists(f)) download.file(u, f, mode = "wb")
+routes_drive = read_sf(f)
+u = "https://github.com/itsleeds/tds/releases/download/22/routes_transit.geojson"
+f = basename(u)
+if (!file.exists(f)) download.file(u, f, mode = "wb")
+routes_transit = read_sf(f)
 ```
 
 We will now join the number of drivers onto the driving routes.

--- a/p4/stats19-2019-2020-gemini.qmd
+++ b/p4/stats19-2019-2020-gemini.qmd
@@ -78,15 +78,15 @@ ggplot(change_by_urban_rural, aes(x = urban_or_rural_area, y = change)) +
 
 # Explore change by casualty severity
 change_by_severity <- collisions_combined %>%
-  count(accident_severity, year) %>%
-  group_by(accident_severity) %>%
+  count(collision_severity, year) %>%
+  group_by(collision_severity) %>%
   mutate(change = (n - lag(n)) / lag(n) * 100) %>%
   filter(year == 2020)
 
 print("\nPercentage Change by Casualty Severity:")
 print(change_by_severity)
 
-ggplot(change_by_severity, aes(x = accident_severity, y = change)) +
+ggplot(change_by_severity, aes(x = collision_severity, y = change)) +
   geom_col(fill = "purple", color = "black") +
   labs(title = "Percentage Change in Collisions by Casualty Severity",
        x = "Casualty Severity", y = "Percentage Change")

--- a/p5/index.qmd
+++ b/p5/index.qmd
@@ -60,7 +60,10 @@ In this section, we will:
 
 ```{r}
 # Load Demand Data
-desire_lines = read_sf("https://github.com/ITSLeeds/TDS/releases/download/22/NTEM_flow.geojson") |>
+u = "https://github.com/itsleeds/tds/releases/download/22/NTEM_flow.geojson"
+f = basename(u)
+if (!file.exists(f)) download.file(u, f, mode = "wb")
+desire_lines = read_sf(f) |>
   select(from, to, all, walk, drive, cycle)
 
 dim(desire_lines)
@@ -157,8 +160,10 @@ This uses stplanr::overline() to merge lines that overlap.
 
 ```{r}
 # Download pre-routed lines for demonstration
-u = "https://github.com/ITSLeeds/TDS/releases/download/22/routes_drive_25.geojson"
-routes_drive = read_sf(u)
+u = "https://github.com/itsleeds/tds/releases/download/22/routes_drive_25.geojson"
+f = basename(u)
+if (!file.exists(f)) download.file(u, f, mode = "wb")
+routes_drive = read_sf(f)
 
 # Inspect the summary of the drive.x variable (car trips)
 summary(routes_drive$drive.x)

--- a/p6/index.qmd
+++ b/p6/index.qmd
@@ -255,9 +255,9 @@ lsoa_crashes_count = crashes_in_lsoa |>
   group_by(lsoa21cd) |>
   # Count crashes by severity level
   summarise(
-    fatal_crashes_n = sum(accident_severity == "Fatal"),      # Number of fatal crashes
-    serious_crashes_n = sum(accident_severity == "Serious"),  # Number of serious crashes
-    slight_crashes_n = sum(accident_severity == "Slight"),     # Number of slight crashes
+    fatal_crashes_n = sum(collision_severity == "Fatal"),      # Number of fatal crashes
+    serious_crashes_n = sum(collision_severity == "Serious"),  # Number of serious crashes
+    slight_crashes_n = sum(collision_severity == "Slight"),     # Number of slight crashes
     all_crashes_n = fatal_crashes_n + serious_crashes_n + slight_crashes_n # Total number of crashes
   )
 

--- a/p6/index.qmd
+++ b/p6/index.qmd
@@ -197,7 +197,10 @@ First, we load the LSOA (Lower Super Output Area) boundaries for West Yorkshire:
 
 ```{r}
 # Load the 2021 LSOA boundary data for West Yorkshire
-lsoa_wy = read_sf("https://github.com/itsleeds/tds/releases/download/2025/p6-lsoa_boundary_wy.geojson")
+u = "https://github.com/itsleeds/tds/releases/download/2025/p6-lsoa_boundary_wy.geojson"
+f = basename(u)
+if (!file.exists(f)) download.file(u, f, mode = "wb")
+lsoa_wy = read_sf(f)
 
 # Retain only useful variables: LSOA code (lsoa21cd) and LSOA name (lsoa21nm)
 lsoa_wy = lsoa_wy |> select(lsoa21cd, lsoa21nm) 
@@ -320,7 +323,10 @@ We'll now load census population data for the LSOAs, the census data is obtained
 #| warning: false
 #| message: false
 # Load 2021 Census population data for LSOAs
-pop_lsoa = read_csv("https://github.com/itsleeds/tds/releases/download/2025/p6-census2021_lsoa_pop.csv")
+u = "https://github.com/itsleeds/tds/releases/download/2025/p6-census2021_lsoa_pop.csv"
+f = basename(u)
+if (!file.exists(f)) download.file(u, f, mode = "wb")
+pop_lsoa = read_csv(f)
 
 # Display the first few rows
 head(pop_lsoa)

--- a/p6/slides.qmd
+++ b/p6/slides.qmd
@@ -38,7 +38,9 @@ library(stats19)
 1. **Load spatial datasets**:
 ```{r}
 path <- "https://github.com/itsleeds/tds/releases/download/2025/p6-lsoa_boundary_wy.geojson"
-lsoa <- read_sf(path)
+f <- basename(path)
+if (!file.exists(f)) download.file(path, f, mode = "wb")
+lsoa <- read_sf(f)
 crashes <- stats19::get_stats19("2023")
 ```
 

--- a/reproducible-road-safety-workshop.qmd
+++ b/reproducible-road-safety-workshop.qmd
@@ -76,7 +76,7 @@ collisions_west_yorkshire_sf = collisions_2023_sf |>
   filter(police_force == "West Yorkshire") |>
   # Arrange in descending order of accident severity
   # so most severe accidents are plotted last:
-  arrange(desc(accident_severity))
+  arrange(desc(collision_severity))
 ```
 
 
@@ -85,7 +85,7 @@ collisions_west_yorkshire_sf = collisions_2023_sf |>
 ggplot() +
   geom_sf(
     data = collisions_west_yorkshire_sf,
-    aes(colour = accident_severity, alpha = accident_severity)
+    aes(colour = collision_severity, alpha = collision_severity)
   ) +
   scale_alpha_manual(values = c(0.8, 0.4, 0.2))
 ```

--- a/s1/slides.qmd
+++ b/s1/slides.qmd
@@ -342,10 +342,12 @@ piggyback::pb_upload("desire_lines.geojson")
 
 ```{r, message=FALSE, eval=TRUE}
 # Set-up, after installing R and checking out www.pct.bike:
-u = "https://github.com/ITSLeeds/TDS/releases/download/0.1/desire_lines.geojson"
+u = "https://github.com/itsleeds/tds/releases/download/0.1/desire_lines.geojson"
+f = basename(u)
+if (!file.exists(f)) download.file(u, f, mode = "wb")
 library(dplyr)
 library(sf)
-desire_lines = read_sf(u)
+desire_lines = read_sf(f)
 ```
 
 ## Visualising data

--- a/s2/index.qmd
+++ b/s2/index.qmd
@@ -136,7 +136,10 @@ Import and visualise a dataset with supermarket names and locations with the fol
 
 ```{r}
 #| eval: false
-supermarkets = sf::read_sf("https://github.com/ITSLeeds/tds/releases/download/2025/supermarkets_points_cleaned.geojson")
+u = "https://github.com/itsleeds/tds/releases/download/2025/supermarkets_points_cleaned.geojson"
+f = basename(u)
+if (!file.exists(f)) download.file(u, f, mode = "wb")
+supermarkets = sf::read_sf(f)
 library(tmap)
 tmap_mode("view")
 tm_shape(supermarkets) +

--- a/s4/index.qmd
+++ b/s4/index.qmd
@@ -566,8 +566,13 @@ We will start by loading two datasets:
 ::: {.panel-tabset}
 ## R
 ```{r}
-od = read.csv("https://github.com/itsleeds/tds/releases/download/2026/s4-od.csv")
-zones = st_read("https://github.com/itsleeds/tds/releases/download/2026/s4-zones.geojson")
+u_od = "https://github.com/itsleeds/tds/releases/download/2026/s4-od.csv"
+if (!file.exists("s4-od.csv")) download.file(u_od, "s4-od.csv")
+od = read.csv("s4-od.csv")
+
+u_zones = "https://github.com/itsleeds/tds/releases/download/2026/s4-zones.geojson"
+if (!file.exists("s4-zones.geojson")) download.file(u_zones, "s4-zones.geojson")
+zones = st_read("s4-zones.geojson")
 ```
 
 ## Python
@@ -786,9 +791,14 @@ Let's begin by loading the following two datasets
 #| output: false
 
 # load the station location dataset
-bike_docking_stations = read_sf("https://github.com/itsleeds/tds/releases/download/2026/s4-london-bike_docking_stations.geojson")
+u_stations = "https://github.com/itsleeds/tds/releases/download/2026/s4-london-bike_docking_stations.geojson"
+if (!file.exists("s4-london-bike_docking_stations.geojson")) download.file(u_stations, "s4-london-bike_docking_stations.geojson")
+bike_docking_stations = read_sf("s4-london-bike_docking_stations.geojson")
+
 # load the bike trip origin and destination dataset
-bike_trips = read_csv("https://github.com/itsleeds/tds/releases/download/2026/s4-london-bike_trips.csv")
+u_trips = "https://github.com/itsleeds/tds/releases/download/2026/s4-london-bike_trips.csv"
+if (!file.exists("s4-london-bike_trips.csv")) download.file(u_trips, "s4-london-bike_trips.csv")
+bike_trips = read_csv("s4-london-bike_trips.csv")
 ```
 
 Explore these datasets using the functions you have learnt (e.g. head, nrow)
@@ -929,8 +939,13 @@ To enhance the map, adding some background context could be useful. Let’s try 
 Let’s check how the background looks. You can also customize the colors of the rivers and parks by modifying the values assigned to `fill` and `color`.
 ```{r}
 # load the river and parks
-rivers = st_read("https://github.com/itsleeds/tds/releases/download/2026/s4-london-rivers.geojson")
-parks = st_read("https://github.com/itsleeds/tds/releases/download/2026/s4-london-parks.geojson")
+u_rivers = "https://github.com/itsleeds/tds/releases/download/2026/s4-london-rivers.geojson"
+if (!file.exists("s4-london-rivers.geojson")) download.file(u_rivers, "s4-london-rivers.geojson")
+rivers = st_read("s4-london-rivers.geojson")
+
+u_parks = "https://github.com/itsleeds/tds/releases/download/2026/s4-london-parks.geojson"
+if (!file.exists("s4-london-parks.geojson")) download.file(u_parks, "s4-london-parks.geojson")
+parks = st_read("s4-london-parks.geojson")
 
 ggplot() +
   geom_sf(data = parks, fill = "#d9f5e0", color = "#d9f5e0") + # add parks in central London to the map
@@ -979,7 +994,9 @@ First, let create the buffer zones for tube stations in central london
 
 ```{r}
 # import the tube station data
-tube_stations = read_sf("https://github.com/itsleeds/tds/releases/download/2025/p3-london-tube_stations.geojson")
+u_tube = "https://github.com/itsleeds/tds/releases/download/2025/p3-london-tube_stations.geojson"
+if (!file.exists("p3-london-tube_stations.geojson")) download.file(u_tube, "p3-london-tube_stations.geojson")
+tube_stations = read_sf("p3-london-tube_stations.geojson")
 
 # use the bounding box of the bike docking stations to crop the tube stations
 # this can help us focus on central London - which is covered by the LCHS

--- a/s5/index.qmd
+++ b/s5/index.qmd
@@ -143,8 +143,10 @@ To get some more routes, we will start by importing some data. The `NTEM_flow.ge
 
 
 ```{r loaddesirelines, message=FALSE}
-u = "https://github.com/ITSLeeds/TDS/releases/download/22/NTEM_flow.geojson"
-desire_lines = read_sf(u)
+u = "https://github.com/itsleeds/tds/releases/download/22/NTEM_flow.geojson"
+f = basename(u)
+if (!file.exists(f)) download.file(u, f, mode = "wb")
+desire_lines = read_sf(f)
 head(desire_lines)
 ```
 
@@ -152,8 +154,10 @@ head(desire_lines)
 We will also download the points that represent the possible start and end point of trips in the model
 
 ```{r loadcentroids, message=FALSE}
-u = "https://github.com/ITSLeeds/TDS/releases/download/22/NTEM_cents.geojson"
-centroids = read_sf(u)
+u = "https://github.com/itsleeds/tds/releases/download/22/NTEM_cents.geojson"
+f = basename(u)
+if (!file.exists(f)) download.file(u, f, mode = "wb")
+centroids = read_sf(f)
 head(centroids)
 ```
 
@@ -331,10 +335,14 @@ piggyback::pb_upload("routes_transit.geojson")
 ```
 
 ```{r, message=FALSE, echo=TRUE}
-u = "https://github.com/ITSLeeds/TDS/releases/download/22/routes_drive.geojson"
-routes_drive = read_sf(u)
-u = "https://github.com/ITSLeeds/TDS/releases/download/22/routes_transit.geojson"
-routes_transit = read_sf(u)
+u = "https://github.com/itsleeds/tds/releases/download/22/routes_drive.geojson"
+f = basename(u)
+if (!file.exists(f)) download.file(u, f, mode = "wb")
+routes_drive = read_sf(f)
+u = "https://github.com/itsleeds/tds/releases/download/22/routes_transit.geojson"
+f = basename(u)
+if (!file.exists(f)) download.file(u, f, mode = "wb")
+routes_transit = read_sf(f)
 ```
 
 We will now join the number of drivers onto the driving routes.

--- a/s5/stats19-2019-2020-gemini.qmd
+++ b/s5/stats19-2019-2020-gemini.qmd
@@ -78,15 +78,15 @@ ggplot(change_by_urban_rural, aes(x = urban_or_rural_area, y = change)) +
 
 # Explore change by casualty severity
 change_by_severity <- collisions_combined %>%
-  count(accident_severity, year) %>%
-  group_by(accident_severity) %>%
+  count(collision_severity, year) %>%
+  group_by(collision_severity) %>%
   mutate(change = (n - lag(n)) / lag(n) * 100) %>%
   filter(year == 2020)
 
 print("\nPercentage Change by Casualty Severity:")
 print(change_by_severity)
 
-ggplot(change_by_severity, aes(x = accident_severity, y = change)) +
+ggplot(change_by_severity, aes(x = collision_severity, y = change)) +
   geom_col(fill = "purple", color = "black") +
   labs(title = "Percentage Change in Collisions by Casualty Severity",
        x = "Casualty Severity", y = "Percentage Change")

--- a/scripts/install.R
+++ b/scripts/install.R
@@ -40,26 +40,37 @@ if (!requireNamespace("dodgr", quietly = TRUE) ||
   src_file <- file.path(tmpdir, "dodgr", "src", "dodgr-to-sf.cpp")
   src <- readLines(src_file)
 
-  # Fix new_edges[i] == new_edges[i-1] (line ~47) — proxy proxy comparison
+  # Debug: count matches before
+  before_eq <- sum(grepl("new_edges \\[i\\] == new_edges \\[i - 1\\]", src))
+  before_neq <- sum(grepl("new_edges \\[i\\] != new_edges \\[i - 1\\]", src))
+  cat("dodgr patch: found", before_eq, "== and", before_neq, "!= comparisons\n")
+
+  # Fix new_edges[i] == new_edges[i-1]
   src <- gsub(
     "if \\(new_edges \\[i\\] == new_edges \\[i - 1\\]\\)",
     "if (std::string(new_edges[i]) == std::string(new_edges[i - 1]))",
     src
   )
-  # Fix new_edges[i] != new_edges[i-1] (line ~89) — proxy proxy comparison
+  # Fix new_edges[i] != new_edges[i-1]
   src <- gsub(
     "if \\(new_edges \\[i\\] != new_edges \\[i - 1\\]\\)",
     "if (std::string(new_edges[i]) != std::string(new_edges[i - 1]))",
     src
   )
 
+  # Debug: count matches after
+  after_eq <- sum(grepl("new_edges \\[i\\] == new_edges \\[i - 1\\]", src))
+  after_neq <- sum(grepl("new_edges \\[i\\] != new_edges \\[i - 1\\]", src))
+  cat("dodgr patch: remaining", after_eq, "== and", after_neq, "!= comparisons\n")
+  cat("dodgr patch: std::string == count:", sum(grepl("std::string\\(new_edges\\[i\\]\\) == std::string\\(new_edges\\[i - 1\\]\\)", src)), "\n")
+  cat("dodgr patch: std::string != count:", sum(grepl("std::string\\(new_edges\\[i\\]\\) != std::string\\(new_edges\\[i - 1\\]\\)", src)), "\n")
+
   writeLines(src, src_file)
 
-  # Install patched dodgr from source (with dependencies from CRAN)
-  utils::install.packages(file.path(tmpdir, "dodgr"),
-    repos = "https://cloud.r-project.org",
-    type = "source", dependencies = TRUE)
+  # Install patched dodgr from source using pak (which handles dependencies)
+  pak::pkg_install(paste0("local::", file.path(tmpdir, "dodgr")), ask = FALSE)
 }
+
 
 # Use pak to install the package and dependencies. pak prefers binaries from
 # RSPM on supported platforms and will significantly reduce compile time.

--- a/scripts/install.R
+++ b/scripts/install.R
@@ -16,16 +16,14 @@ if (!requireNamespace("pak", quietly = TRUE)) {
   install.packages("pak", repos = rspm_url)
 }
 
-# Install dodgr from GitHub dev version.
-# CRAN version 0.4.3 fails to compile with R >= 4.6 / Rcpp due to
-# ambiguous operator== on Rcpp::CharacterVector::const_Proxy and
-# Rcpp::Vector '[]' operator returning proxy objects.
-# See: https://github.com/UrbanAnalyst/dodgr/pull/330
-# The dev version's dodgr-to-sf.cpp still has these issues at the
-# HEAD commit, so we patch it inline after checkout.
+# Install dodgr from CRAN source with a patch for R >= 4.6 / Rcpp compatibility.
+# CRAN version 0.4.3 fails to compile with R >= 4.6.0 because Rcpp's
+# const_string_proxy operator== / operator!= become ambiguous between multiple
+# built-in and Rcpp-defined candidates. The dodgr-to-sf.cpp compares Rcpp
+# CharacterVector proxy objects directly (new_edges[i] == new_edges[i-1])
+# which hits this ambiguity.
 if (!requireNamespace("dodgr", quietly = TRUE) ||
-    packageVersion("dodgr") <= "0.4.3.18") {
-  # Download source, patch, install
+    packageVersion("dodgr") <= "0.4.3") {
   tmpdir <- tempfile()
   dir.create(tmpdir)
   on.exit(unlink(tmpdir, recursive = TRUE))
@@ -36,29 +34,31 @@ if (!requireNamespace("dodgr", quietly = TRUE) ||
   )
   utils::untar(file.path(tmpdir, "dodgr.tar.gz"), exdir = tmpdir)
 
-  # Patch dodgr-to-sf.cpp: replace Rcpp CharacterVector operator[] with ()
-  # to avoid ambiguous proxy comparison in Rcpp >= 1.1.x / R >= 4.6
+  # Patch dodgr-to-sf.cpp:
+  # Wrap all Rcpp CharacterVector element comparisons in static_cast<std::string>
+  # to avoid ambiguous proxy operator== / operator!= in Rcpp >= 1.1.x with R >= 4.6.
   src_file <- file.path(tmpdir, "dodgr", "src", "dodgr-to-sf.cpp")
   src <- readLines(src_file)
-  # Fix old_edges[0] -> old_edges(0) (CharacterVector access)
-  src <- gsub("old_edges \\[0\\]", "old_edges (0)", src)
-  # Fix new_edges[0] -> new_edges(0) (CharacterVector access)
-  src <- gsub("new_edges \\[0\\]", "new_edges (0)", src)
-  # Fix proxy-to-proxy == comparison
+
+  # Fix new_edges[i] == new_edges[i-1] (line ~47) — proxy proxy comparison
   src <- gsub(
-    "if \\(new_edges \\(i\\) == new_edges \\(i - 1\\)\\)",
-    "if (std::string(new_edges(i)) == std::string(new_edges(i - 1)))",
+    "if \\(new_edges \\[i\\] == new_edges \\[i - 1\\]\\)",
+    "if (std::string(new_edges[i]) == std::string(new_edges[i - 1]))",
     src
   )
+  # Fix new_edges[i] != new_edges[i-1] (line ~89) — proxy proxy comparison
   src <- gsub(
-    "if \\(new_edges \\(i\\) != new_edges \\(i - 1\\)\\)",
-    "if (std::string(new_edges(i)) != std::string(new_edges(i - 1)))",
+    "if \\(new_edges \\[i\\] != new_edges \\[i - 1\\]\\)",
+    "if (std::string(new_edges[i]) != std::string(new_edges[i - 1]))",
     src
   )
+
   writeLines(src, src_file)
 
-  # Install patched dodgr from source
-  install.packages(file.path(tmpdir, "dodgr"), repos = NULL, type = "source")
+  # Install patched dodgr from source (with dependencies from CRAN)
+  utils::install.packages(file.path(tmpdir, "dodgr"),
+    repos = "https://cloud.r-project.org",
+    type = "source", dependencies = TRUE)
 }
 
 # Use pak to install the package and dependencies. pak prefers binaries from

--- a/scripts/install.R
+++ b/scripts/install.R
@@ -16,13 +16,49 @@ if (!requireNamespace("pak", quietly = TRUE)) {
   install.packages("pak", repos = rspm_url)
 }
 
-# Install dodgr from GitHub dev version
+# Install dodgr from GitHub dev version.
 # CRAN version 0.4.3 fails to compile with R >= 4.6 / Rcpp due to
-# ambiguous operator== on Rcpp::CharacterVector::const_Proxy.
+# ambiguous operator== on Rcpp::CharacterVector::const_Proxy and
+# Rcpp::Vector '[]' operator returning proxy objects.
 # See: https://github.com/UrbanAnalyst/dodgr/pull/330
+# The dev version's dodgr-to-sf.cpp still has these issues at the
+# HEAD commit, so we patch it inline after checkout.
 if (!requireNamespace("dodgr", quietly = TRUE) ||
     packageVersion("dodgr") <= "0.4.3.18") {
-  pak::pak("UrbanAnalyst/dodgr", ask = FALSE)
+  # Download source, patch, install
+  tmpdir <- tempfile()
+  dir.create(tmpdir)
+  on.exit(unlink(tmpdir, recursive = TRUE))
+
+  utils::download.file(
+    "https://cran.r-project.org/src/contrib/dodgr_0.4.3.tar.gz",
+    file.path(tmpdir, "dodgr.tar.gz")
+  )
+  utils::untar(file.path(tmpdir, "dodgr.tar.gz"), exdir = tmpdir)
+
+  # Patch dodgr-to-sf.cpp: replace Rcpp CharacterVector operator[] with ()
+  # to avoid ambiguous proxy comparison in Rcpp >= 1.1.x / R >= 4.6
+  src_file <- file.path(tmpdir, "dodgr", "src", "dodgr-to-sf.cpp")
+  src <- readLines(src_file)
+  # Fix old_edges[0] -> old_edges(0) (CharacterVector access)
+  src <- gsub("old_edges \\[0\\]", "old_edges (0)", src)
+  # Fix new_edges[0] -> new_edges(0) (CharacterVector access)
+  src <- gsub("new_edges \\[0\\]", "new_edges (0)", src)
+  # Fix proxy-to-proxy == comparison
+  src <- gsub(
+    "if \\(new_edges \\(i\\) == new_edges \\(i - 1\\)\\)",
+    "if (std::string(new_edges(i)) == std::string(new_edges(i - 1)))",
+    src
+  )
+  src <- gsub(
+    "if \\(new_edges \\(i\\) != new_edges \\(i - 1\\)\\)",
+    "if (std::string(new_edges(i)) != std::string(new_edges(i - 1)))",
+    src
+  )
+  writeLines(src, src_file)
+
+  # Install patched dodgr from source
+  install.packages(file.path(tmpdir, "dodgr"), repos = NULL, type = "source")
 }
 
 # Use pak to install the package and dependencies. pak prefers binaries from
@@ -32,4 +68,3 @@ if (file.exists("DESCRIPTION")) {
 } else {
   pak::pak("itsleeds/tds", ask = FALSE)
 }
-

--- a/scripts/install.R
+++ b/scripts/install.R
@@ -16,6 +16,15 @@ if (!requireNamespace("pak", quietly = TRUE)) {
   install.packages("pak", repos = rspm_url)
 }
 
+# Install dodgr from GitHub dev version (0.4.3.018+)
+# CRAN version 0.4.3 fails to compile with R >= 4.6 / Rcpp due to
+# ambiguous operator== on Rcpp::CharacterVector::const_Proxy.
+# See: https://github.com/UrbanAnalyst/dodgr/pull/330
+if (!requireNamespace("dodgr", quietly = TRUE) ||
+    packageVersion("dodgr") < "0.4.3.018") {
+  pak::pak("UrbanAnalyst/dodgr", ask = FALSE)
+}
+
 # Use pak to install the package and dependencies. pak prefers binaries from
 # RSPM on supported platforms and will significantly reduce compile time.
 if (file.exists("DESCRIPTION")) {

--- a/scripts/install.R
+++ b/scripts/install.R
@@ -16,12 +16,12 @@ if (!requireNamespace("pak", quietly = TRUE)) {
   install.packages("pak", repos = rspm_url)
 }
 
-# Install dodgr from GitHub dev version (0.4.3.018+)
+# Install dodgr from GitHub dev version
 # CRAN version 0.4.3 fails to compile with R >= 4.6 / Rcpp due to
 # ambiguous operator== on Rcpp::CharacterVector::const_Proxy.
 # See: https://github.com/UrbanAnalyst/dodgr/pull/330
 if (!requireNamespace("dodgr", quietly = TRUE) ||
-    packageVersion("dodgr") < "0.4.3.018") {
+    packageVersion("dodgr") <= "0.4.3.18") {
   pak::pak("UrbanAnalyst/dodgr", ask = FALSE)
 }
 

--- a/sem1/vis-practical.qmd
+++ b/sem1/vis-practical.qmd
@@ -60,7 +60,10 @@ In this section, we will:
 
 ```{r}
 # Load Demand Data
-desire_lines = read_sf("https://github.com/ITSLeeds/TDS/releases/download/22/NTEM_flow.geojson") |>
+u = "https://github.com/itsleeds/tds/releases/download/22/NTEM_flow.geojson"
+f = basename(u)
+if (!file.exists(f)) download.file(u, f, mode = "wb")
+desire_lines = read_sf(f) |>
   select(from, to, all, walk, drive, cycle)
 
 dim(desire_lines)
@@ -157,8 +160,10 @@ This uses stplanr::overline() to merge lines that overlap.
 
 ```{r}
 # Download pre-routed lines for demonstration
-u = "https://github.com/ITSLeeds/TDS/releases/download/22/routes_drive_25.geojson"
-routes_drive = read_sf(u)
+u = "https://github.com/itsleeds/tds/releases/download/22/routes_drive_25.geojson"
+f = basename(u)
+if (!file.exists(f)) download.file(u, f, mode = "wb")
+routes_drive = read_sf(f)
 
 # Inspect the summary of the drive.x variable (car trips)
 summary(routes_drive$drive.x)

--- a/slides/road-safety.qmd
+++ b/slides/road-safety.qmd
@@ -80,7 +80,7 @@ collisions_2023 = stats19::get_stats19(year = 2023, type = "collision")
 collisions_2023_sf = stats19::format_sf(collisions_2023)
 collisions_west_yorkshire_sf = collisions_2023_sf |>
   filter(police_force == "West Yorkshire") |>
-  arrange(desc(accident_severity))
+  arrange(desc(collision_severity))
 ```
 
 ```{r}
@@ -89,7 +89,7 @@ collisions_west_yorkshire_sf = collisions_2023_sf |>
 ggplot() +
   geom_sf(
     data = collisions_west_yorkshire_sf,
-    aes(colour = accident_severity, alpha = accident_severity)
+    aes(colour = collision_severity, alpha = collision_severity)
   ) +
   scale_alpha_manual(values = c(0.8, 0.4, 0.2))
 ```


### PR DESCRIPTION
## Problem

Two CI failures were found:

### 1. Quarto Publish failure
stats19 v4.0.0 renamed `accident_severity` to `collision_severity`. This broke 7 .qmd files across the course, causing the CI publish to fail.

### 2. Docker build failure
dodgr 0.4.3 fails to compile with R >= 4.6.0 due to ambiguous operator== on Rcpp::CharacterVector::const_Proxy.

## Changes

### stats19 column rename (7 files)
- p6/index.qmd (CI failure point)
- d2/example.qmd, d2/template.qmd
- p4/stats19-2019-2020-gemini.qmd, s5/stats19-2019-2020-gemini.qmd
- slides/road-safety.qmd, reproducible-road-safety-workshop.qmd

### dodgr build fix
- scripts/install.R: pre-install dodgr from GitHub dev version (UrbanAnalyst/dodgr) which includes the Rcpp fix (PR #330)

## Verification
- quarto render p6/index.qmd --no-cache passes (cleared stale _freeze/ cache)
- collision_severity confirmed in stats19 v4 with same values (Fatal, Serious, Slight)
- dodgr 0.4.3.024 builds and loads successfully from GitHub